### PR TITLE
Added entity-to-data-elements mapping implementation

### DIFF
--- a/eav/v1/EavDb/Eav/EavModel.sql
+++ b/eav/v1/EavDb/Eav/EavModel.sql
@@ -91,23 +91,44 @@ INSERT INTO dbo.DataElements
     Id, Description
 )
 VALUES
-    (24, 'Last Name'),
-    (25, 'Initials'),
+    (22, 'Employee Code'),
+    (7014, 'Global Person Code'),
+    (524, 'Last Name'),
+    (24, 'Last Name At Birth'),
     (26, 'Last Name At Birth Prefix'),
-    (27, 'Partner Name'),
-    (35, 'BirthDate'),
-    (36, 'Gender'),
-    (38, 'Employment Indicator'),
-    (39, 'Hire Date'),  -- Datum indienst
     (51, 'First Names'),
-    (94, 'Prefix Titles'),  -- E.g. Drs
-    (95, 'Suffix Titles'),  -- E.g. MA
-    (165, 'First Name To Use'),  -- Roepnaam
+    (165, 'First Name To Use'),
+    (146, 'Formatted Name'),
+    (3000, 'Sort Name'),       
+    (25, 'Initials'),
+    (27, 'Partner Name'),
     (166, 'Partner Name Prefix'),
+    (94, 'Title Prefix'),     -- E.g. Drs
+    (95, 'Title Suffix'),     -- E.g. MA
+    (35, 'Date Of Birth'),
+    (10302568, 'Date Of Death'),
+    (36, 'Gender'),
+    (37, 'Marital Status'),
+    (38, 'Employment Indicator'),  -- In/uitdienst
+    (39, 'Hire Date'),  -- Datum indienst
     (308, 'First Hire Date'),  -- Eerste datum indienst
-    (7014, 'UPI'),
+    (10000018, 'National Identification Number'),
+    (40, 'End Date Employment'),
+    (10520479, 'Discharge Date'),  -- Geplande laatste datum indienst
+    (7212, 'Business Email Address'),
     (7213, 'Private Email Address'),
-    (10520479, 'DischargeDate')  -- Geplande laatste datum indienst
+    (7374, 'Business Phone Number'),
+    (7376, 'Private Phone Number'),
+    (7377, 'Mobile Phone Number'),
+    (10204761, 'Nationality'),
+    -- Address
+    (391, 'Street Name'),
+    (392, 'Street Number'),
+    (393, 'Street Number Additional'),
+    (394, 'Postal Code'),
+    (395, 'City'),
+    (34,  'Country')
+
 GO
 
 -- Insert a test client and some companies below it.

--- a/eav/v1/EavDb/Eav/EavModel.sql
+++ b/eav/v1/EavDb/Eav/EavModel.sql
@@ -79,6 +79,7 @@ INSERT INTO dbo.Templates
     Id, Name
 )
 VALUES
+    (12, 'Land'),
     (15, 'Client'),
     (17, 'Company'),
     (21, 'Employee'),
@@ -91,6 +92,7 @@ INSERT INTO dbo.DataElements
     Id, Description
 )
 VALUES
+    (10, 'Language'),
     (22, 'Employee Code'),
     (7014, 'Global Person Code'),
     (524, 'Last Name'),
@@ -137,9 +139,20 @@ INSERT INTO dbo.Entities
     ParentId, Description, TemplateId
 )
 VALUES
-    (NULL, 'Metatech Nederland', 15),
-    (1, 'Metatech Administratie BV', 17),
-    (1, 'Metatech Constructie', 17),
-    (1, 'Metatech Horeca Services', 17),
-    (1, 'Metatech Wonen', 17)
+    (NULL, 'Nederland', 12),
+    (1, 'Metatech Nederland', 15),
+    (2, 'Metatech Administratie BV', 17),
+    (2, 'Metatech Constructie', 17),
+    (2, 'Metatech Horeca Services', 17),
+    (2, 'Metatech Wonen', 17)
 GO
+
+-- Insert initial Language value on country level.
+INSERT INTO dbo.Mutations
+(
+    EntityId, DataElementId, FieldValue, StartDate, EndDate
+)
+VALUES
+(
+    1, 10, 'NL', '2001-01-01', '9999-12-31'
+)

--- a/eav/v1/WriteApi/DataElement.cs
+++ b/eav/v1/WriteApi/DataElement.cs
@@ -31,6 +31,7 @@ namespace WriteApi
         public const int EndDateEmployment = 40;  // Datum uitdienst
         public const int DischargeDate = 10520479;  // Geplande laatste datum indienst
         public const int Nationality = 10204761;
+        public const int Language = 10;
 
         public static class HomeAddress
         {

--- a/eav/v1/WriteApi/DataElement.cs
+++ b/eav/v1/WriteApi/DataElement.cs
@@ -1,9 +1,45 @@
 ﻿
 namespace WriteApi
 {
-    public static class DataElement
+    public static class EavAttributes
     {
-        public const int LastName = 24;
+        public const int EmployeeCode = 22;
+        public const int GlobalPersonCode = 7014;  // UPI
+        public const int EmploymentIndicator = 38;  // Dienstverband indicatie
+        public const int LastName = 524;
+        public const int LastNameAtBirth = 24;
+        public const int LastNameAtBirthPrefix = 26;
         public const int FirstNames = 51;
+        public const int FirstNameToUse = 165;  // Roepnaam
+        public const int FormattedName = 146;
+        public const int SortName = 3000;
+        public const int Initials = 25;
+        public const int PartnerName = 27;
+        public const int PartnerNamePrefix = 166;
+        public const int TitlePrefix = 94;
+        public const int TitleSuffix = 95;
+        public const int Gender = 36;
+        public const int MaritalStatus = 37;
+        public const int DateOfBirth = 35;
+        public const int DateOfDeath = 10302568;
+        public const int NationalIdentificationNumber = 10000018;
+        public const int BusinessEmailAddress = 7212;
+        public const int PrivateEmailAddress = 7213;
+        public const int BusinessPhoneNumber = 7374;
+        public const int PrivatePhoneNumber = 7376;
+        public const int MobilePhoneNumber = 7377;
+        public const int EndDateEmployment = 40;  // Datum uitdienst
+        public const int DischargeDate = 10520479;  // Geplande laatste datum indienst
+        public const int Nationality = 10204761;
+
+        public static class HomeAddress
+        {
+            public const int StreetName = 391;
+            public const int StreetNumber = 392;
+            public const int StreetNumberAdditional = 393;
+            public const int PostalCode = 394;
+            public const int City = 395;
+            public const int Country = 34;
+        }
     }
 }

--- a/eav/v1/WriteApi/Employee.cs
+++ b/eav/v1/WriteApi/Employee.cs
@@ -1,8 +1,77 @@
+using System;
+
 namespace WriteApi
 {
     public class Employee
     {
-        public string FirstName { get; set; }
+        public int Id { get; set; }
+
+        public string EmployeeCode { get; set; }
+
+        public string GlobalPersonCode { get; set; }
+
+        public string Initials { get; set; }
+
+        public string FirstNames { get; set; }
+
+        public string FirstNameToUse { get; set; }
+
+        public string LastNameAtBirth { get; set; }
+
+        public string LastNameAtBirthPrefix { get; set; }
+
         public string LastName { get; set; }
+
+        public string PartnerName { get; set; }
+
+        public string PartnerNamePrefix { get; set; }
+
+        public string TitlePrefix { get; set; }
+
+        public string TitleSuffix { get; set; }
+
+        public string Gender { get; set; }
+
+        public DateTime? DateOfBirth { get; set; }
+
+        public DateTime? DateOfDeath { get; set; }
+
+        public string NationalIdentificationNumber { get; set; }
+
+        public string EmploymentIndicator { get; set; }
+
+        public string MaritalStatus { get; set; }
+
+        public DateTime? EndDateEmployment { get; set; }
+
+        public string SortName { get; set; }
+
+        public DateTime? DischargeDate { get; set; }
+
+        public string Nationality { get; set; }
+
+        public string BusinessPhoneNumber { get; set; }
+
+        public string PrivatePhoneNumber { get; set; }
+
+        public string MobilePhoneNumber { get; set; }
+
+        public string BusinessEmailAddress { get; set; }
+
+        public string PrivateEmailAddress { get; set; }
+
+        public string FormattedName { get; set; }
+
+        public string HomeAddressStreetName { get; set; }
+
+        public string HomeAddressStreetNumber { get; set; }
+
+        public string HomeAddressStreetNumberAdditional { get; set; }
+
+        public string HomeAddressPostalCode { get; set; }
+
+        public string HomeAddressCity { get; set; }
+
+        public string HomeAddressCountry { get; set; }
     }
 }

--- a/eav/v1/WriteApi/Employee.cs
+++ b/eav/v1/WriteApi/Employee.cs
@@ -6,6 +6,8 @@ namespace WriteApi
     {
         public int Id { get; set; }
 
+        public int CompanyId { get; set; }
+
         public string EmployeeCode { get; set; }
 
         public string GlobalPersonCode { get; set; }
@@ -49,6 +51,8 @@ namespace WriteApi
         public DateTime? DischargeDate { get; set; }
 
         public string Nationality { get; set; }
+
+        public string Language { get; set; }
 
         public string BusinessPhoneNumber { get; set; }
 

--- a/eav/v1/WriteApi/EmployeeMappingConfiguration.cs
+++ b/eav/v1/WriteApi/EmployeeMappingConfiguration.cs
@@ -1,0 +1,48 @@
+﻿namespace WriteApi
+{
+    using Mapping;
+
+    internal class EmployeeMappingConfiguration : EntityMappingConfiguration<Employee>
+    {
+        protected override void ConfigureMapping()
+        {
+            HasProperty(x => x.EmployeeCode, EavAttributes.EmployeeCode)
+                .HasProperty(x => x.GlobalPersonCode, EavAttributes.GlobalPersonCode)
+                .HasProperty(x => x.Initials, EavAttributes.Initials)
+                .HasProperty(x => x.FirstNames, EavAttributes.FirstNames)
+                .HasProperty(x => x.FirstNameToUse, EavAttributes.FirstNameToUse)
+                .HasProperty(x => x.LastNameAtBirth, EavAttributes.LastNameAtBirth)
+                .HasProperty(x => x.LastNameAtBirthPrefix, EavAttributes.LastNameAtBirthPrefix)
+                .HasProperty(x => x.LastName, EavAttributes.LastName)
+                .HasProperty(x => x.PartnerName, EavAttributes.PartnerName)
+                .HasProperty(x => x.PartnerNamePrefix, EavAttributes.PartnerNamePrefix)
+                .HasProperty(x => x.TitlePrefix, EavAttributes.TitlePrefix)
+                .HasProperty(x => x.TitleSuffix, EavAttributes.TitleSuffix)
+                .HasProperty(x => x.Gender, EavAttributes.Gender)
+                .HasProperty(x => x.DateOfBirth, EavAttributes.DateOfBirth)
+                .HasProperty(x => x.DateOfDeath, EavAttributes.DateOfDeath)
+                .HasProperty(x => x.NationalIdentificationNumber, EavAttributes.NationalIdentificationNumber)
+                .HasProperty(x => x.EmploymentIndicator, EavAttributes.EmploymentIndicator)
+                .HasProperty(x => x.HomeAddressCountry, EavAttributes.HomeAddress.Country)
+                .HasProperty(x => x.HomeAddressCity, EavAttributes.HomeAddress.City)
+                .HasProperty(x => x.HomeAddressPostalCode, EavAttributes.HomeAddress.PostalCode)
+                .HasProperty(x => x.HomeAddressStreetName, EavAttributes.HomeAddress.StreetName)
+                .HasProperty(x => x.HomeAddressStreetNumber, EavAttributes.HomeAddress.StreetNumber)
+                .HasProperty(x => x.HomeAddressStreetNumberAdditional,
+                    EavAttributes.HomeAddress.StreetNumberAdditional)
+                .HasProperty(x => x.BusinessPhoneNumber, EavAttributes.BusinessPhoneNumber)
+                .HasProperty(x => x.PrivatePhoneNumber, EavAttributes.PrivatePhoneNumber)
+                .HasProperty(x => x.MobilePhoneNumber, EavAttributes.MobilePhoneNumber)
+                .HasProperty(x => x.BusinessEmailAddress, EavAttributes.BusinessEmailAddress)
+                .HasProperty(x => x.PrivateEmailAddress, EavAttributes.PrivateEmailAddress)
+                .HasProperty(x => x.MaritalStatus, EavAttributes.MaritalStatus)
+                .HasProperty(x => x.EndDateEmployment, EavAttributes.EndDateEmployment)
+                .HasProperty(x => x.FormattedName, EavAttributes.FormattedName)
+                .HasProperty(x => x.SortName, EavAttributes.SortName)
+                .HasProperty(x => x.DischargeDate, EavAttributes.DischargeDate)
+                .HasProperty(x => x.Nationality, EavAttributes.Nationality);
+        }
+    }
+
+}
+

--- a/eav/v1/WriteApi/EmployeeMappingConfiguration.cs
+++ b/eav/v1/WriteApi/EmployeeMappingConfiguration.cs
@@ -40,7 +40,8 @@
                 .HasProperty(x => x.FormattedName, EavAttributes.FormattedName)
                 .HasProperty(x => x.SortName, EavAttributes.SortName)
                 .HasProperty(x => x.DischargeDate, EavAttributes.DischargeDate)
-                .HasProperty(x => x.Nationality, EavAttributes.Nationality);
+                .HasProperty(x => x.Nationality, EavAttributes.Nationality)
+                .HasProperty(x => x.Language, EavAttributes.Language);
         }
     }
 

--- a/eav/v1/WriteApi/EmployeeRepository.cs
+++ b/eav/v1/WriteApi/EmployeeRepository.cs
@@ -71,6 +71,11 @@ namespace WriteApi
 
             // Perform some basic validations. Validation errors should probably be handled
             // in an alternative way.
+            if (employee.CompanyId <= 0)
+            {
+                throw new ArgumentException("Invalid Company ID", nameof(employee.CompanyId));
+            }
+
             if (string.IsNullOrWhiteSpace(firstName))
             {
                 throw new ArgumentException("Invalid First Name", nameof(employee.FirstNames));
@@ -91,10 +96,11 @@ namespace WriteApi
             await using var connection = new SqlConnection(_connectionString);
             await connection.OpenAsync();
 
-            const string sql = @"INSERT INTO dbo.Entities (Description, TemplateId)
-                VALUES (@FullName, @TemplateId); SELECT @@IDENTITY";
+            const string sql = @"INSERT INTO dbo.Entities (ParentId, Description, TemplateId)
+                VALUES (@ParentId, @FullName, @TemplateId); SELECT @@IDENTITY";
 
             var cmd = new SqlCommand(sql);
+            AddCommandParameter(cmd, "@ParentId", employee.CompanyId, SqlDbType.Int);
             AddCommandParameter(cmd, "@FullName", fullName, SqlDbType.VarChar);
             AddCommandParameter(cmd, "@TemplateId", templateId, SqlDbType.Int);
             cmd.Connection = connection;

--- a/eav/v1/WriteApi/EmployeeRepository.cs
+++ b/eav/v1/WriteApi/EmployeeRepository.cs
@@ -1,17 +1,18 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using WriteApi.Mapping;
 
 namespace WriteApi
 {
-    using System.Data;
-
     public class EmployeeRepository
     {
         private readonly string _connectionString;
         private readonly ILogger<EmployeeRepository> _logger;
+        private readonly IDataElementMapper<Employee> _dataElementMapper;
 
         public EmployeeRepository(ILogger<EmployeeRepository> logger)
         {
@@ -21,6 +22,8 @@ namespace WriteApi
                 throw new ArgumentNullException(nameof(_connectionString));
             }
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _dataElementMapper = new FluentDataElementMapper<Employee>(
+                new EmployeeMappingConfiguration());
         }
 
         public async Task Update(int employeeId, Employee employee)
@@ -30,21 +33,21 @@ namespace WriteApi
                 throw new ArgumentException("Invalid Employee ID", nameof(employeeId));
             }
 
-            var firstName = employee.FirstName;
+            var firstName = employee.FirstNames;
             var lastName = employee.LastName;
 
             var startDate = DateTime.Now.Date;
             var endDate = DateTime.MaxValue;
 
             // TODO: Following commands should only be run when the employee data element values have actually changed.
-            await SetMutationDeleted(startDate, employeeId, DataElement.LastName);
-            await SetMutationDeleted(startDate, employeeId, DataElement.FirstNames);
+            await SetMutationDeleted(startDate, employeeId, EavAttributes.LastName);
+            await SetMutationDeleted(startDate, employeeId, EavAttributes.FirstNames);
             await InsertMutations(new List<Mutation>
             {
                 new Mutation
                 {
                     EntityId = employeeId,
-                    DataElementId = DataElement.LastName,
+                    DataElementId = EavAttributes.LastName,
                     FieldValue = lastName,
                     StartDate = startDate,
                     EndDate = endDate,
@@ -53,7 +56,7 @@ namespace WriteApi
                 new Mutation
                 {
                     EntityId = employeeId,
-                    DataElementId = DataElement.FirstNames,
+                    DataElementId = EavAttributes.FirstNames,
                     FieldValue = firstName,
                     StartDate = startDate,
                     EndDate = endDate,
@@ -63,14 +66,14 @@ namespace WriteApi
 
         public async Task<int> Add(Employee employee)
         {
-            var firstName = employee.FirstName;
+            var firstName = employee.FirstNames;
             var lastName = employee.LastName;
 
             // Perform some basic validations. Validation errors should probably be handled
             // in an alternative way.
             if (string.IsNullOrWhiteSpace(firstName))
             {
-                throw new ArgumentException("Invalid First Name", nameof(employee.FirstName));
+                throw new ArgumentException("Invalid First Name", nameof(employee.FirstNames));
             }
 
             if (string.IsNullOrWhiteSpace(lastName))
@@ -79,8 +82,7 @@ namespace WriteApi
             }
 
             var fullName = $"{lastName}, {firstName}";
-            // TODO: Replace by enum value or external constant.
-            const int templateId = 21;
+            const int templateId = (int) EntityType.Employee;
 
             var startDate = DateTime.Now.Date;
             var endDate = DateTime.MaxValue.Date;
@@ -108,27 +110,23 @@ namespace WriteApi
                 return newEmployeeId;
             }
 
-            await InsertMutations(new List<Mutation>
+            var dataElements = _dataElementMapper.MapToDataElements(employee);
+            var mutations = new List<Mutation>();
+
+            foreach (var dataElement in dataElements)
             {
-                new Mutation
+                _logger.LogInformation($"Adding mutation for data element {dataElement.Id}, value '{dataElement.Value}'");
+                mutations.Add(new Mutation
                 {
                     EntityId = newEmployeeId,
-                    DataElementId = DataElement.LastName,
-                    FieldValue = lastName,
+                    DataElementId = dataElement.Id,
+                    FieldValue = dataElement.Value.ToString(),
                     StartDate = startDate,
                     EndDate = endDate
+                });
+            }
 
-                },
-                new Mutation
-                {
-                    EntityId = newEmployeeId,
-                    DataElementId = DataElement.FirstNames,
-                    FieldValue = firstName,
-                    StartDate = startDate,
-                    EndDate = endDate
-                }
-            });
-
+            await InsertMutations(mutations);
             return newEmployeeId;
         }
 

--- a/eav/v1/WriteApi/EmployeeRepository.cs
+++ b/eav/v1/WriteApi/EmployeeRepository.cs
@@ -37,7 +37,7 @@ namespace WriteApi
             var lastName = employee.LastName;
 
             var startDate = DateTime.Now.Date;
-            var endDate = DateTime.MaxValue;
+            var endDate = DateTime.MaxValue.Date;
 
             // TODO: Following commands should only be run when the employee data element values have actually changed.
             await SetMutationDeleted(startDate, employeeId, EavAttributes.LastName);

--- a/eav/v1/WriteApi/Mapping/BaseEntityMapper.cs
+++ b/eav/v1/WriteApi/Mapping/BaseEntityMapper.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+
+namespace WriteApi.Mapping
+{
+    internal abstract class BaseEntityMapper<TEntity> : IEntityMapper<TEntity>
+        where TEntity : class
+    {
+        //private readonly DataTypeConverter _converter = new DataTypeConverter();
+
+        protected Dictionary<int, ElementPropertyMapper<TEntity>> Mappers = new Dictionary<int, ElementPropertyMapper<TEntity>>();
+
+        public void MapToEntity(TEntity entity, DataElementRow dataElementRow)
+        {
+            if (HasMapper(dataElementRow.Id))
+            {
+                MapValueToProperty(entity, dataElementRow.Id, dataElementRow.Value);
+            }
+            //else
+            //{
+            //    entity.SetUnmappedDataElementValue(dataElementRow.Id,
+            //        dataElementRow.ExportTag,
+            //        _converter.ConvertTo(dataElementRow.DataType.GetConversionType(), dataElementRow.Value));
+            //}
+        }
+
+        private void MapValueToProperty(TEntity entity, int dataElementId, string fieldValue)
+        {
+            Mappers[dataElementId].SetPropertyValue(entity, fieldValue);
+        }
+
+        private bool HasMapper(int dataElementId)
+        {
+            return Mappers.ContainsKey(dataElementId);
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/DataElement.cs
+++ b/eav/v1/WriteApi/Mapping/DataElement.cs
@@ -1,0 +1,31 @@
+﻿
+namespace WriteApi.Mapping
+{
+    public class DataElement
+    {
+        public int Id { get; set; }
+
+        public int EntityId { get; set; }
+
+        public int ParentEntityId { get; set; }
+
+        public EntityType EntityType { get; set; }
+
+        public object Value { get; set; }
+
+        public DataElementDataType DataType { get; set; }
+
+        public DataElement(int id, object value)
+        {
+            Id = id;
+            Value = value;
+        }
+
+        public DataElement(int id, int entityId, object value)
+        {
+            Id = id;
+            EntityId = entityId;
+            Value = value;
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/DataElementDataType.cs
+++ b/eav/v1/WriteApi/Mapping/DataElementDataType.cs
@@ -1,0 +1,12 @@
+﻿namespace WriteApi.Mapping
+{
+    public enum DataElementDataType
+    {
+        Undefined = 0,
+        AlphaNumeric = 1,
+        Numeric = 2,
+        Date = 3,
+        Currency = 4,
+        Boolean = 5
+    }
+}

--- a/eav/v1/WriteApi/Mapping/DataElementDataTypeExtensions.cs
+++ b/eav/v1/WriteApi/Mapping/DataElementDataTypeExtensions.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace WriteApi.Mapping
+{
+    internal static class DataElementDataTypeExtensions
+    {
+        public static Type GetConversionType(this DataElementDataType dataElementDataType)
+        {
+            switch (dataElementDataType)
+            {
+                case DataElementDataType.AlphaNumeric:
+                    return typeof(string);
+
+                case DataElementDataType.Numeric:
+                    return typeof(float);
+
+                case DataElementDataType.Date:
+                    return typeof(DateTime);
+
+                case DataElementDataType.Boolean:
+                    return typeof(bool);
+            }
+
+            return null;
+        }
+
+        public static bool IsUsedFor(this DataElementDataType dataElementDataType, Type type)
+        {
+            var underlyingType = Nullable.GetUnderlyingType(type);
+
+            if (underlyingType != null)
+                type = underlyingType;
+
+            switch (dataElementDataType)
+            {
+                case DataElementDataType.AlphaNumeric:
+                    return type == typeof(string);
+                case DataElementDataType.Numeric:
+                    return type == typeof(int) ||
+                           type == typeof(long) ||
+                           type == typeof(short) ||
+                           type == typeof(double) ||
+                           type == typeof(float) ||
+                           type == typeof(decimal) ||
+                           type.IsEnum;
+                case DataElementDataType.Date:
+                    return type == typeof(DateTime);
+                case DataElementDataType.Currency:
+                    return type == typeof(double) ||
+                           type == typeof(float) ||
+                           type == typeof(decimal);
+                case DataElementDataType.Boolean:
+                    return type == typeof(bool);
+            }
+
+            return false;
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/DataElementMapper.cs
+++ b/eav/v1/WriteApi/Mapping/DataElementMapper.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace WriteApi.Mapping
+{
+    internal abstract class DataElementMapper<TEntity> : IDataElementMapper<TEntity>
+        where TEntity : class
+    {
+        private readonly Dictionary<int, PropertyDataElementMapper<TEntity>> _propertyMappersByDataElementId =
+            new Dictionary<int, PropertyDataElementMapper<TEntity>>();
+
+        protected void DefineMapping(int dataElementId, PropertyInfo property)
+        {
+            var mapper = new PropertyDataElementMapper<TEntity>(property, dataElementId);
+            _propertyMappersByDataElementId.Add(dataElementId, mapper);
+        }
+
+        public List<DataElement> MapToDataElements(TEntity entity)
+        {
+            var result = new List<DataElement>();
+
+            foreach (var propertyMapping in _propertyMappersByDataElementId.Values)
+            {
+                var dataElement = propertyMapping.GetDataElementForProperty(entity);
+                if (dataElement != null)
+                {
+                    result.Add(dataElement);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/DataElementRow.cs
+++ b/eav/v1/WriteApi/Mapping/DataElementRow.cs
@@ -1,0 +1,22 @@
+﻿
+namespace WriteApi.Mapping
+{
+    public class DataElementRow
+    {
+        public int Id { get; }
+
+        public string Value { get; }
+
+        public DataElementDataType DataType { get; }
+
+        public string ExportTag { get; }
+
+        public DataElementRow(int id, string value, DataElementDataType dataType, string exportTag = null)
+        {
+            Id = id;
+            Value = value;
+            DataType = dataType;
+            ExportTag = exportTag;
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/DataTypeConversion.cs
+++ b/eav/v1/WriteApi/Mapping/DataTypeConversion.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace WriteApi.Mapping
+{
+    public static class DataTypeConversion
+    {
+        private static readonly ConcurrentDictionary<Type, DataElementDataType> _cache
+            = new ConcurrentDictionary<Type, DataElementDataType>();
+
+        public static DataElementDataType GetDataTypeForType(Type type)
+        {
+            if (!_cache.ContainsKey(type))
+            {
+                var result = DetermineDataTypeForType(type);
+                _cache.TryAdd(type, result);
+
+                return result;
+            }
+
+            return _cache[type];
+        }
+
+        private static DataElementDataType DetermineDataTypeForType(Type type)
+        {
+            foreach (DataElementDataType dataType in Enum.GetValues(typeof(DataElementDataType)))
+            {
+                if (dataType.IsUsedFor(type))
+                    return dataType;
+            }
+
+            return DataElementDataType.Undefined;
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/DataTypeConverter.cs
+++ b/eav/v1/WriteApi/Mapping/DataTypeConverter.cs
@@ -1,0 +1,94 @@
+﻿namespace WriteApi.Mapping
+{
+    using System;
+    using System.Globalization;
+
+    internal class DataTypeConverter
+    {
+        private readonly CultureInfo _culture;
+
+        public DataTypeConverter()
+            : this(new CultureInfo("nl"))
+        {
+        }
+
+        public DataTypeConverter(CultureInfo cultureInfo)
+        {
+            _culture = cultureInfo ?? throw new ArgumentNullException(nameof(cultureInfo));
+        }
+
+        public virtual object ConvertTo(Type type, object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            if (type == typeof(string))
+            {
+                return value.ToString();
+            }
+
+            return ConvertToValueType(value, GetResultType(type), _culture);
+        }
+
+        private object ConvertToValueType(object value, Type type, CultureInfo culture)
+        {
+            if (type.IsEnum && int.TryParse(value.ToString(), out int enumValue)
+                            && Enum.IsDefined(type, enumValue))
+                return Enum.Parse(type, value.ToString() ?? string.Empty);
+
+            if (type == typeof(int))
+                return Convert.ToInt32(value, _culture.NumberFormat);
+
+            if (type == typeof(long))
+                return Convert.ToInt64(value, _culture.NumberFormat);
+
+            if (type == typeof(short))
+                return Convert.ToInt16(value, _culture.NumberFormat);
+
+            if (type == typeof(DateTime))
+                return Convert.ToDateTime(value, _culture.DateTimeFormat);
+
+            if (type == typeof(decimal))
+                return Convert.ToDecimal(value, _culture.NumberFormat);
+
+            if (type == typeof(double))
+                return Convert.ToDouble(value, _culture.NumberFormat);
+
+            if (type == typeof(float))
+                return Convert.ToSingle(value, _culture.NumberFormat);
+
+            if (type == typeof(bool))
+                return Convert.ToBoolean(value);
+
+            if (type == typeof(char))
+                return Convert.ToChar(value);
+
+            if (type == typeof(byte))
+                return Convert.ToByte(value, _culture.NumberFormat);
+
+            if (type == typeof(sbyte))
+                return Convert.ToSByte(value, _culture.NumberFormat);
+
+            if (type == typeof(uint))
+                return Convert.ToUInt32(value, _culture.NumberFormat);
+
+            if (type == typeof(ulong))
+                return Convert.ToUInt64(value, _culture.NumberFormat);
+
+            if (type == typeof(ushort))
+                return Convert.ToUInt16(value, _culture.NumberFormat);
+
+            return value;
+        }
+
+        private static Type GetResultType(Type destinationType)
+        {
+            var valueType = destinationType;
+            return destinationType.IsGenericType && destinationType.GetGenericTypeDefinition() == typeof(Nullable<>)
+                ? destinationType.GetGenericArguments()[0]
+                : valueType;
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/ElementPropertyMapper.cs
+++ b/eav/v1/WriteApi/Mapping/ElementPropertyMapper.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Reflection;
+
+namespace WriteApi.Mapping
+{
+    internal class ElementPropertyMapper<TEntity>
+        where TEntity : class
+    {
+        private readonly DataTypeConverter _typeConverter;
+
+        public string PropertyName { get; }
+
+        public int? DataElementId { get; }
+
+        internal Action<TEntity, object> Setter { get; }
+
+        public Type ReturnType { get; }
+
+        public Type EntityType { get; }
+
+        public ElementPropertyMapper(PropertyInfo property)
+        {
+            _typeConverter = new DataTypeConverter();
+
+            if (property == null)
+                throw new ArgumentNullException(nameof(property));
+
+            PropertyName = property.Name;
+            ReturnType = property.PropertyType;
+            Setter = property.SetValue;
+            EntityType = typeof(TEntity);
+        }
+
+        public ElementPropertyMapper(int dataElementId, PropertyInfo property)
+            : this(property)
+        {
+            DataElementId = dataElementId;
+        }
+
+        public void SetPropertyValue(TEntity instance, object value)
+        {
+            var val = _typeConverter.ConvertTo(ReturnType, value);
+            Setter.Invoke(instance, val);
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/ElementPropertyMapping.cs
+++ b/eav/v1/WriteApi/Mapping/ElementPropertyMapping.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+
+namespace WriteApi.Mapping
+{
+    public class ElementPropertyMapping
+    {
+        public int DataElementId { get; }
+
+        public PropertyInfo Property { get; }
+
+        public ElementPropertyMapping(int dataElementId, PropertyInfo property)
+        {
+            DataElementId = dataElementId;
+            Property = property;
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/EntityMappingConfiguration.cs
+++ b/eav/v1/WriteApi/Mapping/EntityMappingConfiguration.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace WriteApi.Mapping
+{
+    public abstract class EntityMappingConfiguration<TEntity>
+        where TEntity : class
+    {
+        private readonly Dictionary<int, ElementPropertyMapping> _mappings
+            = new Dictionary<int, ElementPropertyMapping>();
+
+        protected EntityMappingConfiguration()
+        {
+            Configure();
+        }
+
+        public IEnumerable<ElementPropertyMapping> Mappings => _mappings.Values;
+
+        public ElementPropertyMapping GetMapping(int dataElementId)
+        {
+            return _mappings.TryGetValue(dataElementId, out var mapping) ? mapping : null;
+        }
+
+        public EntityMappingConfiguration<TEntity> HasProperty<TPropertyValue>(Expression<Func<TEntity, TPropertyValue>> property,
+            int dataElementId)
+        {
+            var mapping = new ElementPropertyMapping(dataElementId, GetProperty(property));
+            if (_mappings.ContainsKey(dataElementId))
+            {
+                throw new Exception(
+                    $"Data element ID {dataElementId} has already been mapped for {mapping.Property.Name}");
+            }
+
+            _mappings.Add(dataElementId, mapping);
+            return this;
+        }
+
+        protected abstract void ConfigureMapping();
+
+        private static PropertyInfo GetProperty<TPropertyValue>(Expression<Func<TEntity, TPropertyValue>> property)
+        {
+            var member = (MemberExpression)property.Body;
+            var propertyName = member.Member.Name;
+            return typeof(TEntity).GetProperty(propertyName);
+        }
+
+        private void Configure()
+        {
+            ConfigureMapping();
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/EntityType.cs
+++ b/eav/v1/WriteApi/Mapping/EntityType.cs
@@ -1,0 +1,14 @@
+﻿
+namespace WriteApi.Mapping
+{
+    public enum EntityType
+    {
+        Undefined = 0,  // Note: A value of 0 actually corresponds to 'System' level' but we are not supposed to store data on that level
+        Client = 15,
+        Company = 17,
+        Employee = 21,
+        Contract = 49,
+        Assignment = 800,
+        OrganizationalUnit = 6000
+    }
+}

--- a/eav/v1/WriteApi/Mapping/FluentDataElementMapper.cs
+++ b/eav/v1/WriteApi/Mapping/FluentDataElementMapper.cs
@@ -1,0 +1,16 @@
+﻿namespace WriteApi.Mapping
+{
+    internal class FluentDataElementMapper<TEntity> : DataElementMapper<TEntity> where TEntity : class
+    {
+        public FluentDataElementMapper(EntityMappingConfiguration<TEntity> configuration)
+        {
+            foreach (var mapping in configuration.Mappings)
+            {
+                var property = mapping.Property;
+                var dataElementId = mapping.DataElementId;
+
+                DefineMapping(dataElementId, property);
+            }
+        }
+    }
+}

--- a/eav/v1/WriteApi/Mapping/FluentEntityMapper.cs
+++ b/eav/v1/WriteApi/Mapping/FluentEntityMapper.cs
@@ -1,0 +1,16 @@
+﻿namespace WriteApi.Mapping
+{
+    internal class FluentEntityMapper<TEntity> : BaseEntityMapper<TEntity> where TEntity : class
+    {
+        public FluentEntityMapper(EntityMappingConfiguration<TEntity> configuration)
+        {
+            foreach(var mapping in configuration.Mappings)
+            {
+                Mappers.Add(mapping.DataElementId,
+                    new ElementPropertyMapper<TEntity>(mapping.DataElementId, mapping.Property));
+            }
+        }
+
+
+    }
+}

--- a/eav/v1/WriteApi/Mapping/IDataElementMapper.cs
+++ b/eav/v1/WriteApi/Mapping/IDataElementMapper.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace WriteApi.Mapping
+{
+    public interface IDataElementMapper<in TEntity>
+        where TEntity : class
+    {
+        List<DataElement> MapToDataElements(TEntity entity);
+    }
+}

--- a/eav/v1/WriteApi/Mapping/IEntityMapper.cs
+++ b/eav/v1/WriteApi/Mapping/IEntityMapper.cs
@@ -1,0 +1,9 @@
+﻿
+namespace WriteApi.Mapping
+{
+    public interface IEntityMapper<in TEntity>
+        where TEntity : class
+    {
+        void MapToEntity(TEntity entity, DataElementRow dataElementRow);
+    }
+}

--- a/eav/v1/WriteApi/Mapping/PropertyDataElementMapper.cs
+++ b/eav/v1/WriteApi/Mapping/PropertyDataElementMapper.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+
+namespace WriteApi.Mapping
+{
+    internal class PropertyDataElementMapper<TEntity> where TEntity : class
+    {
+        public int DataElementId { get; }
+
+        public PropertyInfo Property { get; }
+
+        public DataElementDataType DataType { get; }
+
+        internal PropertyDataElementMapper(PropertyInfo property, int dataElementId)
+        {
+            DataElementId = dataElementId;
+            Property = property;
+            DataType = DataTypeConversion.GetDataTypeForType(property.PropertyType);
+        }
+
+        public DataElement GetDataElementForProperty(TEntity entity)
+        {
+            object value = Property.GetValue(entity);
+
+            if (value == null)
+                return null;
+
+            if (Property.PropertyType.IsEnum)
+                value = (int)value;
+
+            return new DataElement(DataElementId, value) { DataType = DataType };
+        }
+    }
+}

--- a/eav/v1/WriteApi/Test.http
+++ b/eav/v1/WriteApi/Test.http
@@ -3,8 +3,10 @@ PUT http://localhost:3000/employees
 Content-Type: application/json
 
 {
-  "FirstName":"John", 
-  "LastName":"Doo" 
+  "FirstNames":"John", 
+  "LastName":"Doo",
+  "EmploymentIndicator":"1",
+  "MobilePhoneNumber":"0612345678"
 }
 
 ###
@@ -15,6 +17,6 @@ POST http://localhost:3000/employees/{{employeeId}}
 Content-Type: application/json
 
 {
-  "FirstName":"Johhny",
+  "FirstNames":"Johhny",
   "LastName":"Depp"
 }

--- a/eav/v1/WriteApi/Test.http
+++ b/eav/v1/WriteApi/Test.http
@@ -3,6 +3,7 @@ PUT http://localhost:3000/employees
 Content-Type: application/json
 
 {
+  "CompanyId": 3,
   "FirstNames":"John", 
   "LastName":"Doo",
   "EmploymentIndicator":"1",


### PR DESCRIPTION
Note: The Mapping sub folder in the WriteApi project contains somewhat more classes than we are actually using right now, just to keep all mapping stuff bundled together (including data-elements-to-entity-mapping)