### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,30 @@
 
 ## Compose docker containers
 To compose and start Docker containers on your local machine (in the background), open a Powershell window and enter the following command:
+```
 docker-compose -f .\docker-compose.yml up -d --build
+```
 
 To stop the containers, enter the following command:
+```
 docker-compose down
+```
 
 ## Run container for specific application with rebuild
+```
 docker-compose up --build <application-name>
+```
 Example:
+```
 docker-compose up --build readapi
+```
 
 Any dependencies defined in a 'depends_on' section of the application (in the docker-compose.yml file) will be resolved, i.e. the containers that the container depends on are also started.
 The --build argument forces a rebuild of the container.
+
+## Run at scale
+When we want to run the application, we need to create an over capacity on the side which processes the queue. 
+This can easily done by running the application 3 times:
+```
+docker-compose up --build -d --scale mutationprocessor=3
+```

--- a/eav/v1/MutationExtractor/Change.cs
+++ b/eav/v1/MutationExtractor/Change.cs
@@ -5,27 +5,24 @@ namespace MutationExtractor
     public class Change
     {
         public int TenantId { get; set; }
-
         public int EntityId { get; set; }
-
-        public DateTime? EntityStartDate { get; set; }
-
-        public DateTime? EntityEndDate { get; set; }
+        
+        public int EntityParentId { get; set; }
 
         public bool EntityDeleted { get; set; }
 
-        public int TemplateId { get; set; }
+        public int EntityTemplateId { get; set; }
 
         public int MutationId { get; set; }
 
         public int FieldId { get; set; }
 
-        public DateTime? StartDate { get; set; }
+        public DateTime? MutationStartDate { get; set; }
 
-        public DateTime? EndDate { get; set; }
+        public DateTime? MutationEndDate { get; set; }
 
-        public object Value { get; set; }
+        public object FieldValue { get; set; }
 
-        public bool IsDeleted { get; set; }
+        public bool MutationDeleted { get; set; }
     }
 }

--- a/eav/v1/MutationExtractor/Database/DatabaseRepository.cs
+++ b/eav/v1/MutationExtractor/Database/DatabaseRepository.cs
@@ -23,6 +23,18 @@ namespace MutationExtractor.Database
 
         public async Task<bool> Verify(CancellationToken cancellationToken)
         {
+            for(var i = 1; i <= 10; i++)
+            {
+                _logger.LogInformation("Connection to database, attempt: " + i);
+                if (await CanConnectToDatabase(cancellationToken)) return true;
+                await Task.Delay(1000, cancellationToken);
+            }
+
+            return false;
+        }
+
+        private async Task<bool> CanConnectToDatabase(CancellationToken cancellationToken)
+        {
             try
             {
                 await using var connection = new SqlConnection(_connectionString);
@@ -35,7 +47,8 @@ namespace MutationExtractor.Database
             }
             catch (SqlException e)
             {
-                _logger.LogError("Couldn't connect to database.", e);
+                _logger.LogError("Can't verify the database connection.", e);
+                _logger.LogError(e.Message, e);
             }
 
             return false;
@@ -46,8 +59,20 @@ namespace MutationExtractor.Database
             await using var connection = new SqlConnection(_connectionString);
             await connection.OpenAsync(cancellationToken);
 
-            const string sql = @"SELECT Id, EntityId, DataElementId, FieldValue, StartDate,
-                                    EndDate, Deleted FROM dbo.Mutations";
+            const string sql = @"SELECT 
+                                       e.TenantId,
+                                       e.Id as EntityId,
+                                       e.ParentId as EntityParentId,
+                                       e.Deleted as EntityDeleted,
+                                       e.TemplateId as EntityTemplateId,
+                                       m.Id as MutationId,
+                                       m.DataElementId as FieldId,
+                                       m.FieldValue,
+                                       m.StartDate as MutationStartDate,
+                                       m.EndDate as MutationEndDate,
+                                       m.Deleted as MutationDeleted
+                                FROM dbo.Mutations as m
+                                INNER JOIN dbo.Entities as e ON e.Id = m.EntityId";
             var command = connection.CreateCommand();
             command.CommandText = sql;
 
@@ -56,13 +81,17 @@ namespace MutationExtractor.Database
             {
                 var change = new Change
                 {
-                    MutationId = await GetColumnValue<int>(reader, "Id"),
-                    EntityId = await GetColumnValue<int>(reader, "EntityId"),
-                    FieldId = await GetColumnValue<int>(reader, "DataElementId"),
-                    Value = await GetColumnValue<object>(reader, "DataElementId"),
-                    StartDate = await GetColumnValue<DateTime>(reader, "StartDate"),
-                    EndDate = await GetColumnValue<DateTime>(reader, "EndDate"),
-                    IsDeleted = await GetColumnValue<bool>(reader, "Deleted"),
+                    TenantId = await GetColumnValue<int>(reader, nameof(Change.TenantId)),
+                    EntityId = await GetColumnValue<int>(reader, nameof(Change.EntityId)),
+                    EntityParentId = await GetColumnValue<int>(reader, nameof(Change.EntityParentId)),
+                    EntityDeleted = await GetColumnValue<bool>(reader, nameof(Change.EntityDeleted)), 
+                    EntityTemplateId = await GetColumnValue<int>(reader, nameof(Change.EntityTemplateId)),
+                    MutationId = await GetColumnValue<int>(reader, nameof(Change.MutationId)),
+                    FieldId = await GetColumnValue<int>(reader, nameof(Change.FieldId)),
+                    FieldValue = await GetColumnValue<object>(reader, nameof(Change.FieldValue)),
+                    MutationStartDate = await GetColumnValue<DateTime>(reader, nameof(Change.MutationStartDate)),
+                    MutationEndDate = await GetColumnValue<DateTime>(reader, nameof(Change.MutationEndDate)),
+                    MutationDeleted = await GetColumnValue<bool>(reader, nameof(Change.MutationDeleted))
                 };
                 yield return change;
             }

--- a/eav/v1/MutationExtractor/Database/DatabaseRepository.cs
+++ b/eav/v1/MutationExtractor/Database/DatabaseRepository.cs
@@ -23,11 +23,11 @@ namespace MutationExtractor.Database
 
         public async Task<bool> Verify(CancellationToken cancellationToken)
         {
-            for(var i = 1; i <= 10; i++)
+            for(var i = 1; i <= 100; i++)
             {
                 _logger.LogInformation("Connection to database, attempt: " + i);
-                if (await CanConnectToDatabase(cancellationToken)) return true;
-                await Task.Delay(1000, cancellationToken);
+                if (await CanConnectToDatabase(cancellationToken).ConfigureAwait(false)) return true;
+                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
             }
 
             return false;

--- a/eav/v1/MutationExtractor/Queue/QueueRepository.cs
+++ b/eav/v1/MutationExtractor/Queue/QueueRepository.cs
@@ -1,11 +1,8 @@
 using System;
-using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
-using Azure.Storage.Queues.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -28,7 +25,7 @@ namespace MutationExtractor.Queue
         {
             try
             {
-                var result = await _client.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+                var result = await _client.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
                 if (result == null || result.Status == 201 || result.Status == 204)
                 {
                     return true;

--- a/eav/v1/MutationExtractor/Queue/QueueRepository.cs
+++ b/eav/v1/MutationExtractor/Queue/QueueRepository.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
+using Azure.Storage.Queues.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -38,10 +41,11 @@ namespace MutationExtractor.Queue
             return false;
         }
 
+        // TODO: error reporting
         public async Task AddMessage<T>(T message, CancellationToken cancellationToken)
         {
-            var json = JsonSerializer.Serialize(message);
-            await _client.SendMessageAsync(json, cancellationToken);
+            var finalMessage = JsonSerializer.Serialize(message);
+            await _client.SendMessageAsync(finalMessage, cancellationToken);
         }
     }
 }

--- a/eav/v1/MutationExtractor/Worker.cs
+++ b/eav/v1/MutationExtractor/Worker.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -22,17 +21,15 @@ namespace MutationExtractor
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            if (!await _queue.Ensure(stoppingToken))
+            if (!await _queue.Ensure(stoppingToken).ConfigureAwait(false))
             {
                 _logger.LogError("Couldn't ensure that Queue is there.");
-                await Task.CompletedTask;
                 return;
             }
 
-            if (!await _database.Verify(stoppingToken))
+            if (!await _database.Verify(stoppingToken).ConfigureAwait(true))
             {
                 _logger.LogError("Couldn't verify database connection.");
-                await Task.CompletedTask;
                 return;
             }
 

--- a/eav/v1/MutationExtractor/Worker.cs
+++ b/eav/v1/MutationExtractor/Worker.cs
@@ -38,14 +38,12 @@ namespace MutationExtractor
 
             while (!stoppingToken.IsCancellationRequested)
             {
-                var changes = _database.GetChanges(stoppingToken).ConfigureAwait(true);
+                var changes = _database.GetChanges(stoppingToken).ConfigureAwait(false);
 
                 await foreach (var change in changes.WithCancellation(stoppingToken))
                 {
-                    var messageGuid = Guid.NewGuid();
-                    _logger.LogInformation("Create Message: {guid}", messageGuid);
-                    string message = JsonSerializer.Serialize(change);
-                    await _queue.AddMessage(message, stoppingToken).ConfigureAwait(false);
+                   _logger.LogInformation("Create Message for Entity ID: {entityId} Mutation ID {mutationId}", change.EntityId, change.MutationId);
+                    await _queue.AddMessage(change, stoppingToken).ConfigureAwait(false);
                 }
 
                 _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);

--- a/eav/v1/MutationProcessor/Change.cs
+++ b/eav/v1/MutationProcessor/Change.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Text.Json.Serialization;
+using MutationProcessor.Queue;
 
 namespace MutationProcessor
 {
     public class Change
     {
         public int TenantId { get; set; }
+        
         public int EntityId { get; set; }
         
         public int EntityParentId { get; set; }
@@ -21,6 +24,7 @@ namespace MutationProcessor
 
         public DateTime? MutationEndDate { get; set; }
 
+        [JsonConverter(typeof(FieldValueConverter))]
         public object FieldValue { get; set; }
 
         public bool MutationDeleted { get; set; }

--- a/eav/v1/MutationProcessor/Change.cs
+++ b/eav/v1/MutationProcessor/Change.cs
@@ -5,19 +5,27 @@ namespace MutationProcessor
     public class Change
     {
         public int TenantId { get; set; }
+
         public int EntityId { get; set; }
-        
+
         public DateTime? EntityStartDate { get; set; }
+
         public DateTime? EntityEndDate { get; set; }
+
         public bool EntityDeleted { get; set; }
+
         public int TemplateId { get; set; }
-        
-        
+
         public int MutationId { get; set; }
+
         public int FieldId { get; set; }
+
         public DateTime? StartDate { get; set; }
+
         public DateTime? EndDate { get; set; }
+
         public object Value { get; set; }
+
         public bool IsDeleted { get; set; }
     }
 }

--- a/eav/v1/MutationProcessor/Change.cs
+++ b/eav/v1/MutationProcessor/Change.cs
@@ -5,27 +5,24 @@ namespace MutationProcessor
     public class Change
     {
         public int TenantId { get; set; }
-
         public int EntityId { get; set; }
-
-        public DateTime? EntityStartDate { get; set; }
-
-        public DateTime? EntityEndDate { get; set; }
+        
+        public int EntityParentId { get; set; }
 
         public bool EntityDeleted { get; set; }
 
-        public int TemplateId { get; set; }
+        public int EntityTemplateId { get; set; }
 
         public int MutationId { get; set; }
 
         public int FieldId { get; set; }
 
-        public DateTime? StartDate { get; set; }
+        public DateTime? MutationStartDate { get; set; }
 
-        public DateTime? EndDate { get; set; }
+        public DateTime? MutationEndDate { get; set; }
 
-        public object Value { get; set; }
+        public object FieldValue { get; set; }
 
-        public bool IsDeleted { get; set; }
+        public bool MutationDeleted { get; set; }
     }
 }

--- a/eav/v1/MutationProcessor/Database/DatabaseWriter.cs
+++ b/eav/v1/MutationProcessor/Database/DatabaseWriter.cs
@@ -121,13 +121,6 @@ namespace MutationProcessor.Database
             var mutationFilter = Builders<Entity>.Filter.And(
                 Builders<Entity>.Filter.Eq(x => x.Id, change.EntityId),
                 Builders<Entity>.Filter.Ne("Mutations.MutationId", change.MutationId));
-            var mutationFilter2 = new BsonDocument("$and", new BsonArray
-            {
-                new BsonDocument("_id",
-                    new BsonDocument("$eq", change.EntityId)),
-                new BsonDocument("Mutations.MutationId",
-                    new BsonDocument("$ne", change.MutationId))
-            });
             var update = Builders<Entity>.Update.AddToSet(x => x.Mutations, new Mutation(change));
             return await collection.UpdateOneAsync(mutationFilter, update, new UpdateOptions(), cancellationToken).ConfigureAwait(true);
         }
@@ -136,8 +129,7 @@ namespace MutationProcessor.Database
         {
             var mutationFilter = Builders<Entity>.Filter.And( 
                                     Builders<Entity>.Filter.Eq(x => x.Id, change.EntityId),
-                                    Builders<Entity>.Filter.ElemMatch(x => x.Mutations, 
-                                        Builders<Mutation>.Filter.Eq(x => x.MutationId, change.MutationId)));
+                                    Builders<Entity>.Filter.Eq("Mutations.MutationId", change.MutationId));
             var update = Builders<Entity>.Update.Set(x => x.Mutations[-1], new Mutation(change));
             
             await collection.UpdateOneAsync(mutationFilter, update, new UpdateOptions(), cancellationToken).ConfigureAwait(true);

--- a/eav/v1/MutationProcessor/Database/DatabaseWriter.cs
+++ b/eav/v1/MutationProcessor/Database/DatabaseWriter.cs
@@ -98,7 +98,7 @@ namespace MutationProcessor.Database
         {
             var options = new CreateIndexOptions();
             var indexModel = new CreateIndexModel<Entity>(
-                Builders<Entity>.IndexKeys.Ascending(nameof(Mutation) + "." + nameof(Mutation.MutationId)), options);
+                Builders<Entity>.IndexKeys.Ascending(nameof(Entity.Mutations) + "." + nameof(Mutation.MutationId)), options);
             await collection.Indexes.CreateOneAsync(indexModel);
         }
 

--- a/eav/v1/MutationProcessor/Database/DatabaseWriter.cs
+++ b/eav/v1/MutationProcessor/Database/DatabaseWriter.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace MutationProcessor.Database
@@ -108,10 +107,9 @@ namespace MutationProcessor.Database
             var entityFilter = Builders<Entity>.Filter.Eq(x => x.Id, change.EntityId);
             var fullInsert = Builders<Entity>.Update.Combine(
                 Builders<Entity>.Update.SetOnInsert(x => x.Id, change.EntityId),
-                Builders<Entity>.Update.Set(x => x.TemplateId, change.TemplateId),
-                Builders<Entity>.Update.Set(x => x.StartDate, change.EntityStartDate),
-                Builders<Entity>.Update.Set(x => x.EndDate, change.EntityEndDate),
-                Builders<Entity>.Update.Set(x => x.IsDeleted, change.IsDeleted)
+                Builders<Entity>.Update.Set(x => x.ParentId, change.EntityParentId),
+                Builders<Entity>.Update.Set(x => x.TemplateId, change.EntityTemplateId),
+                Builders<Entity>.Update.Set(x => x.IsDeleted, change.EntityDeleted)
             );
             return await collection.UpdateOneAsync(entityFilter, fullInsert, upsert, cancellationToken);
         }

--- a/eav/v1/MutationProcessor/Database/DatabaseWriter.cs
+++ b/eav/v1/MutationProcessor/Database/DatabaseWriter.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace MutationProcessor.Database
@@ -51,7 +52,7 @@ namespace MutationProcessor.Database
                 // That would be preferred as it would be a single database call, now it's several
 
                 _logger.LogInformation($"b1: Upserting entity {change.EntityId}");
-                var entityResult =  await EnsureEntity(change, collection, cancellationToken).ConfigureAwait(true);
+                var entityResult =  await EnsureEntity(change, collection, cancellationToken).ConfigureAwait(false);
 
                 if (entityResult.UpsertedId != null)
                 {
@@ -95,10 +96,7 @@ namespace MutationProcessor.Database
 
         private static async Task CreateIndexes(IMongoCollection<Entity> collection)
         {
-            var options = new CreateIndexOptions
-            {
-                Unique = true
-            };
+            var options = new CreateIndexOptions();
             var indexModel = new CreateIndexModel<Entity>(
                 Builders<Entity>.IndexKeys.Ascending(nameof(Mutation) + "." + nameof(Mutation.MutationId)), options);
             await collection.Indexes.CreateOneAsync(indexModel);
@@ -109,6 +107,7 @@ namespace MutationProcessor.Database
             var upsert = new UpdateOptions { IsUpsert = true };
             var entityFilter = Builders<Entity>.Filter.Eq(x => x.Id, change.EntityId);
             var fullInsert = Builders<Entity>.Update.Combine(
+                Builders<Entity>.Update.SetOnInsert(x => x.Id, change.EntityId),
                 Builders<Entity>.Update.Set(x => x.TemplateId, change.TemplateId),
                 Builders<Entity>.Update.Set(x => x.StartDate, change.EntityStartDate),
                 Builders<Entity>.Update.Set(x => x.EndDate, change.EntityEndDate),
@@ -119,17 +118,26 @@ namespace MutationProcessor.Database
         
         private static async Task<UpdateResult> AddMutationIfNotExist(Change change, IMongoCollection<Entity> collection, CancellationToken cancellationToken)
         {
-            var mutationFilter = Builders<Entity>.Filter.Not(
-                Builders<Entity>.Filter.Where(x => x.Id == change.EntityId) &
-                Builders<Entity>.Filter.ElemMatch(x => x.Mutations, Builders<Mutation>.Filter.Eq(x => x.MutationId, change.MutationId)));
+            var mutationFilter = Builders<Entity>.Filter.And(
+                Builders<Entity>.Filter.Eq(x => x.Id, change.EntityId),
+                Builders<Entity>.Filter.Ne("Mutations.MutationId", change.MutationId));
+            var mutationFilter2 = new BsonDocument("$and", new BsonArray
+            {
+                new BsonDocument("_id",
+                    new BsonDocument("$eq", change.EntityId)),
+                new BsonDocument("Mutations.MutationId",
+                    new BsonDocument("$ne", change.MutationId))
+            });
             var update = Builders<Entity>.Update.AddToSet(x => x.Mutations, new Mutation(change));
             return await collection.UpdateOneAsync(mutationFilter, update, new UpdateOptions(), cancellationToken).ConfigureAwait(true);
         }
         
         private static async Task UpdateMutation(Change change, IMongoCollection<Entity> collection, CancellationToken cancellationToken)
         {
-            var mutationFilter = Builders<Entity>.Filter.Where(x => x.Id == change.EntityId) &
-                                 Builders<Entity>.Filter.ElemMatch(x => x.Mutations, Builders<Mutation>.Filter.Eq(x => x.MutationId, change.MutationId));
+            var mutationFilter = Builders<Entity>.Filter.And( 
+                                    Builders<Entity>.Filter.Eq(x => x.Id, change.EntityId),
+                                    Builders<Entity>.Filter.ElemMatch(x => x.Mutations, 
+                                        Builders<Mutation>.Filter.Eq(x => x.MutationId, change.MutationId)));
             var update = Builders<Entity>.Update.Set(x => x.Mutations[-1], new Mutation(change));
             
             await collection.UpdateOneAsync(mutationFilter, update, new UpdateOptions(), cancellationToken).ConfigureAwait(true);

--- a/eav/v1/MutationProcessor/Database/Entity.cs
+++ b/eav/v1/MutationProcessor/Database/Entity.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
@@ -11,23 +10,17 @@ namespace MutationProcessor.Database
         public Entity(Change change)
         {
             Id = change.EntityId;
-            StartDate = change.EntityStartDate;
-            EndDate = change.EntityEndDate;
-            TemplateId = change.TemplateId;
+            ParentId = change.EntityParentId;
+            TemplateId = change.EntityTemplateId;
             IsDeleted = change.EntityDeleted;
         }
 
         [BsonId]
         [BsonRepresentation(BsonType.Int64)]
         public int Id { get; }
-
-        [BsonElement]
-        [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
-        public DateTime? StartDate { get; }
         
         [BsonElement]
-        [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
-        public DateTime? EndDate { get; }
+        public int ParentId { get; }
 
         [BsonElement]
         public int TemplateId { get; }

--- a/eav/v1/MutationProcessor/Database/Mutation.cs
+++ b/eav/v1/MutationProcessor/Database/Mutation.cs
@@ -23,11 +23,11 @@ namespace MutationProcessor.Database
         public Mutation(Change change)
         {
             MutationId = change.MutationId;
+            StartDate = change.MutationStartDate;
+            EndDate = change.MutationEndDate;
+            IsDeleted = change.MutationDeleted;
             FieldId = change.FieldId;
-            StartDate = change.StartDate;
-            EndDate = change.EndDate;
-            Value = change.Value;
-            IsDeleted = change.IsDeleted;
+            Value = change.FieldValue;
         }
     }
 }

--- a/eav/v1/MutationProcessor/Queue/FieldValueConverter.cs
+++ b/eav/v1/MutationProcessor/Queue/FieldValueConverter.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MutationProcessor.Queue
+{
+    public class FieldValueConverter : JsonConverter<object>
+    {
+        public override object Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            // When there's a value, this value is not empty and doesn't start with a zero, try to make it a number
+            if (!string.IsNullOrEmpty(value) && IsNumeric(value) && value[0] != '0')
+            {
+                return long.Parse(value!);
+            }
+            
+            // TODO: Consider booleans and other field types
+
+            return string.IsNullOrEmpty(value) ? null : value.Trim();
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            object dateTimeValue,
+            JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static bool IsNumeric(string value) => value.All(char.IsNumber);
+    }
+}

--- a/eav/v1/MutationProcessor/Queue/QueueReader.cs
+++ b/eav/v1/MutationProcessor/Queue/QueueReader.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/eav/v1/MutationProcessor/Queue/QueueReader.cs
+++ b/eav/v1/MutationProcessor/Queue/QueueReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,7 +47,18 @@ namespace MutationProcessor.Queue
             
             foreach (var message in messages.Value)
             {
-                var change = JsonSerializer.Deserialize<Change>(message.MessageText);
+                Change change;
+                try
+                {
+                    var messageText = message.MessageText;
+                    change = JsonSerializer.Deserialize<Change>(messageText);
+                    
+                }
+                catch (JsonException e)
+                {
+                    Console.WriteLine(e.Message);
+                    continue;
+                }
                 yield return new Message(message.MessageId, message.PopReceipt, change);
             }
         }

--- a/eav/v1/MutationProcessor/Worker.cs
+++ b/eav/v1/MutationProcessor/Worker.cs
@@ -43,7 +43,7 @@ namespace MutationProcessor
                 {
                     var change = message.Change;
                     _logger.LogInformation("a1. Process Mutation with Entity ID: {entityId}; MutationId: {mutationId}", change.EntityId, change.MutationId);
-                    if (await _writer.Append(change, stoppingToken).ConfigureAwait(true))
+                    if (await _writer.Append(change, stoppingToken).ConfigureAwait(false))
                     {
                         _logger.LogInformation("a2. Successful processed Entity ID: {entityId}; MutationId: {mutationId}",
                             change.EntityId, change.MutationId);
@@ -56,7 +56,7 @@ namespace MutationProcessor
                 }
 
                 _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                await Task.Delay(100, stoppingToken).ConfigureAwait(true);
+                await Task.Delay(100, stoppingToken).ConfigureAwait(false);
             }
         }
     }

--- a/eav/v1/v1.sln
+++ b/eav/v1/v1.sln
@@ -6,6 +6,7 @@ MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Infrastructure", "Infrastructure", "{1FE50C88-5DDA-4FC0-BDD8-A9B838F3AD01}"
 ProjectSection(SolutionItems) = preProject
 	docker-compose.yml = docker-compose.yml
+	..\..\README.md = ..\..\README.md
 EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadApi", "ReadApi\ReadApi.csproj", "{E66F563D-42D5-4C23-9BF0-E00E1CC301DA}"


### PR DESCRIPTION
- Queueing goes now without double JSON Serialization
- Mutation inserting into MongoDB is now fixed so it indeed finds the right entity
- Extractor and Processor are more robust against failures
- When starting up, connections such as database connections are retried
- Made the Change object real all from database(except TenantId)
- When dequeueing, data is deserialized to long or string
- Ability to scale up added to the readme.md
